### PR TITLE
feature(team-service): restrict preferred team setting to federated m…

### DIFF
--- a/src/main/java/es/org/cxn/backapp/service/impl/DefaultTeamService.java
+++ b/src/main/java/es/org/cxn/backapp/service/impl/DefaultTeamService.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 
+import es.org.cxn.backapp.model.FederateState;
 import es.org.cxn.backapp.model.UserEntity;
 import es.org.cxn.backapp.model.persistence.team.PersistentTeamEntity;
 import es.org.cxn.backapp.repository.TeamEntityRepository;
@@ -123,6 +124,10 @@ public final class DefaultTeamService implements TeamService {
 
         final var userEntity = userOptional.get();
         final var teamEntity = teamOptional.get();
+
+        if (!userEntity.getFederateState().getState().equals(FederateState.FEDERATE)) {
+            throw new TeamServiceException("Member with email: " + userEmail + " is not federated.");
+        }
 
         if (userEntity.getTeamPreferred() != null) {
             if (userEntity.getTeamPreferred().getName().equals(teamName)) {

--- a/src/test/java/es/org/cxn/backapp/test/unit/services/TeamServiceTest.java
+++ b/src/test/java/es/org/cxn/backapp/test/unit/services/TeamServiceTest.java
@@ -51,7 +51,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import es.org.cxn.backapp.model.FederateState;
 import es.org.cxn.backapp.model.UserEntity;
+import es.org.cxn.backapp.model.persistence.PersistentFederateStateEntity;
 import es.org.cxn.backapp.model.persistence.team.PersistentTeamEntity;
 import es.org.cxn.backapp.model.persistence.user.PersistentUserEntity;
 import es.org.cxn.backapp.model.persistence.user.UserProfile;
@@ -486,7 +488,9 @@ class TeamServiceTest {
 
         PersistentTeamEntity team = new PersistentTeamEntity(teamName, "Category A", "Description A");
         PersistentUserEntity user = (PersistentUserEntity) createUser(userEmail);
-
+        final var federateState = new PersistentFederateStateEntity();
+        federateState.setState(FederateState.FEDERATE);
+        user.setFederateState(federateState);
         when(teamEntityRepository.findById(teamName)).thenReturn(Optional.of(team));
         when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
         when(userRepository.save(user)).thenReturn(user);


### PR DESCRIPTION
…embers only

Modify DefaultTeamService to allow setting a preferred team exclusively for federated members, ensuring non-federated users cannot assign a preferred team.