### PR TITLE
feat(user): add unsubscribe_date column and expose it in member info

### DIFF
--- a/src/main/java/es/org/cxn/backapp/model/UserEntity.java
+++ b/src/main/java/es/org/cxn/backapp/model/UserEntity.java
@@ -28,6 +28,7 @@ package es.org.cxn.backapp.model;
  */
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 import es.org.cxn.backapp.model.persistence.PersistentAddressEntity;
@@ -148,6 +149,13 @@ public interface UserEntity extends Serializable {
     PersistentTeamEntity getTeamPreferred();
 
     /**
+     * Get the unsubscribe initial action date time.
+     *
+     * @return The initial unsubscribe action start date time.
+     */
+    LocalDateTime getUnsubscribeDate();
+
+    /**
      * Checks if the user's account is enabled.
      *
      * @return {@code true} if the account is enabled, {@code false} otherwise.
@@ -258,5 +266,12 @@ public interface UserEntity extends Serializable {
      * @param teamPreferred The team preferred.
      */
     void setTeamPreferred(PersistentTeamEntity teamPreferred);
+
+    /**
+     * Sets unsubscribe date with time.
+     *
+     * @param date The unsubscribe start action initial moment.
+     */
+    void setUnsubscribeDate(LocalDateTime date);
 
 }

--- a/src/main/java/es/org/cxn/backapp/model/form/responses/user/UserDataResponse.java
+++ b/src/main/java/es/org/cxn/backapp/model/form/responses/user/UserDataResponse.java
@@ -28,6 +28,7 @@ package es.org.cxn.backapp.model.form.responses.user;
  */
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -71,13 +72,17 @@ import es.org.cxn.backapp.model.persistence.user.UserType;
  * @param assignedTeamName  The team name assigned to this user. Can be null.
  * @param preferredTeamName The team name that user preferred.
  * @param federateState     The user federate state.
+ * @param unsubscribeDate   Unsubscribe date when user initiate process. Date
+ *                          with no time.
  *
  * @author Santiago Paz Perez
  */
 public record UserDataResponse(String dni, String name, String firstSurname, String secondSurname, String gender,
         LocalDate birthDate, String email, UserType kindMember, AddressResponse userAddress,
-        Set<UserRoleName> userRoles, String assignedTeamName, String preferredTeamName, FederateState federateState) {
+        Set<UserRoleName> userRoles, String assignedTeamName, String preferredTeamName, FederateState federateState,
+        String unsubscribeDate) {
 
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     /**
      * Constructs a {@code UserDataResponse} record from all parameters.
      * <p>
@@ -101,11 +106,13 @@ public record UserDataResponse(String dni, String name, String firstSurname, Str
      * @param assignedTeamName  The team name assigned to this user. Can be null.
      * @param preferredTeamName The team name that user preferred.
      * @param federateState     The federate state.
+     * @param unsubscribeDate   Unsubscribe date when user initiate process. Date
+     *                          with no time.
      */
     public UserDataResponse(final String dni, final String name, final String firstSurname, final String secondSurname,
             final String gender, final LocalDate birthDate, final String email, final UserType kindMember,
             final AddressResponse userAddress, final Set<UserRoleName> userRoles, final String assignedTeamName,
-            final String preferredTeamName, final FederateState federateState) {
+            final String preferredTeamName, final FederateState federateState, String unsubscribeDate) {
         this.dni = dni;
         this.name = name;
         this.firstSurname = firstSurname;
@@ -119,6 +126,7 @@ public record UserDataResponse(String dni, String name, String firstSurname, Str
         this.assignedTeamName = assignedTeamName;
         this.preferredTeamName = preferredTeamName;
         this.federateState = federateState;
+        this.unsubscribeDate = unsubscribeDate;
     }
 
     /**
@@ -137,7 +145,8 @@ public record UserDataResponse(String dni, String name, String firstSurname, Str
                 user.getEmail(), user.getKindMember(), new AddressResponse(user.getAddress()), extractUserRoles(user),
                 Optional.ofNullable(user.getTeamAssigned()).map(TeamEntity::getName).orElse(null),
                 Optional.ofNullable(user.getTeamPreferred()).map(TeamEntity::getName).orElse(null),
-                user.getFederateState().getState());
+                user.getFederateState().getState(), Optional.ofNullable(user.getUnsubscribeDate())
+                        .map(dateTime -> dateTime.toLocalDate().format(DATE_FORMATTER)).orElse(null));
     }
 
     /**

--- a/src/main/java/es/org/cxn/backapp/model/persistence/user/PersistentUserEntity.java
+++ b/src/main/java/es/org/cxn/backapp/model/persistence/user/PersistentUserEntity.java
@@ -28,6 +28,7 @@ package es.org.cxn.backapp.model.persistence.user;
 
 import java.io.Serial;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -129,6 +130,12 @@ public class PersistentUserEntity implements UserEntity {
     @Enumerated(EnumType.STRING)
     private UserType kindMember = UserType.SOCIO_NUMERO;
 
+    /**
+     * Date time when user initiate unsubscribe proccess.
+     */
+    @Column(name = "unsubscribe_date", nullable = true, unique = false)
+    @Builder.Default
+    private LocalDateTime unsubscribeDate = null;
     /**
      * User status boolean, enabled or disiabled, true or false.
      */

--- a/src/main/java/es/org/cxn/backapp/service/impl/DefaultUserService.java
+++ b/src/main/java/es/org/cxn/backapp/service/impl/DefaultUserService.java
@@ -30,6 +30,7 @@ package es.org.cxn.backapp.service.impl;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
@@ -525,6 +526,7 @@ public final class DefaultUserService implements UserService {
 
         if (passwordEncoder.matches(validationPass, userEntity.getPassword())) {
             userEntity.setEnabled(false);
+            userEntity.setUnsubscribeDate(LocalDateTime.now());
             userRepository.save(userEntity);
             try {
                 emailService.sendUnsubscribe(userEntity.getEmail(), userEntity.getCompleteName());

--- a/src/main/resources/db/changelog/structure/user_tables.yaml
+++ b/src/main/resources/db/changelog/structure/user_tables.yaml
@@ -259,4 +259,14 @@ databaseChangeLog:
     - modifyDataType:
         tableName: user_federative_data
         columnName: dni_last_update
-        newDataType: date  
+        newDataType: date
+- changeSet:
+    id: add_unsubscribe_data
+    author: Santiago
+    changes:
+    - addColumn:
+            tableName: users
+            columns:
+            - column:
+                  name: unsubscribe_date
+                  type: datetime

--- a/src/test/java/es/org/cxn/backapp/test/unit/response/UserDataResponseTest.java
+++ b/src/test/java/es/org/cxn/backapp/test/unit/response/UserDataResponseTest.java
@@ -133,7 +133,7 @@ class UserDataResponseTest {
         // Act
         UserDataResponse response = new UserDataResponse(USER_DNI, USER_NAME, USER_FIRST_SURNAME, USER_SECOND_SURNAME,
                 USER_GENDER, USER_BIRTH_DATE, USER_EMAIL, kindMember, address, roles, assignedTeamName,
-                preferredTeamName, FederateState.FEDERATE);
+                preferredTeamName, FederateState.FEDERATE, null);
 
         // Assert
         assertEquals(USER_DNI, response.dni());
@@ -212,7 +212,7 @@ class UserDataResponseTest {
         UserDataResponse response = new UserDataResponse(USER_DNI, USER_NAME, USER_FIRST_SURNAME, USER_SECOND_SURNAME,
                 USER_GENDER, USER_BIRTH_DATE, USER_EMAIL, UserType.SOCIO_NUMERO,
                 new AddressResponse("PostalCode", "Apartment", "Building", "Street", "City", "Country", "SubCountry"),
-                roles, assignedTeamName, preferredTeamName, FederateState.FEDERATE);
+                roles, assignedTeamName, preferredTeamName, FederateState.FEDERATE, null);
 
         // Act
         Set<UserRoleName> responseRoles = response.userRoles();

--- a/src/test/java/es/org/cxn/backapp/test/unit/response/UserListDataResponseTest.java
+++ b/src/test/java/es/org/cxn/backapp/test/unit/response/UserListDataResponseTest.java
@@ -232,7 +232,7 @@ class UserListDataResponseTest {
                         "SubCountry" // subCountryName
                 ), // userAddress (mocked value)
                 Set.of(UserRoleName.ROLE_SOCIO), // userRoles (mocked value)
-                "TeamNameAssigned", "TeamNamePreferred", FederateState.FEDERATE);
+                "TeamNameAssigned", "TeamNamePreferred", FederateState.FEDERATE, null);
 
         List<UserDataResponse> users = List.of(user1);
         UserListDataResponse response = new UserListDataResponse(users);
@@ -256,7 +256,7 @@ class UserListDataResponseTest {
                         "Other SubCountry" // subCountryName
                 ), // userAddress (mocked value)
                 Set.of(UserRoleName.ROLE_ADMIN), // userRoles (mocked value)
-                "TeamNameAssigned", "TeamNamePreferred", FederateState.FEDERATE));
+                "TeamNameAssigned", "TeamNamePreferred", FederateState.FEDERATE, null));
 
         assertEquals(1, response.usersList().size()); // Ensure original list is unchanged
         assertEquals(2, copiedList.size()); // The copied list should be changed


### PR DESCRIPTION
Added a new column `unsubscribe_date` to the users table to track when a user initiates the unsubscribe process. The value is set when a user unsubscribes and remains null otherwise.

Updated service and controller layers to include this information in the member detail response endpoint.